### PR TITLE
Fix for new cython

### DIFF
--- a/doublemetaphone/doublemetaphone.pyx
+++ b/doublemetaphone/doublemetaphone.pyx
@@ -6,15 +6,16 @@ from libcpp.vector cimport vector
 cdef extern from "double_metaphone.h" nogil :
     void DoubleMetaphone(string s, vector[string] *c)
 
-cpdef tuple doublemetaphone(basestring s):
+cpdef tuple doublemetaphone(object s):
     cdef string cpp_string = _bstring(s)
     cdef vector[string] codes
     DoubleMetaphone(cpp_string, &codes)
     return codes[0].c_str().decode('utf-8'), codes[1].c_str().decode('utf-8')
 
-cdef bytes _bstring(basestring s):
-    if type(s) is unicode:
-        # fast path for most common case(s)
+cdef bytes _bstring(object s):
+    if isinstance(s, str):
         return s.encode('utf-8')
-    else : # safe because of basestring
-        return <char *>s
+    elif isinstance(s, bytes):
+        return s
+    else:
+        return str(s).encode('utf-8')


### PR DESCRIPTION
Build on 3.12 failed with 
```
× Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [40 lines of output]
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
      cdef bytes _bstring(basestring s):
          if type(s) is unicode:
              # fast path for most common case(s)
              return s.encode('utf-8')
          else : # safe because of basestring
              return <char *>s
                             ^
      ------------------------------------------------------------
      
      doublemetaphone/doublemetaphone.pyx:20:23: Unicode objects only support coercion to Py_UNICODE*.
      Compiling doublemetaphone/doublemetaphone.pyx because it changed.
      [1/1] Cythonizing doublemetaphone/doublemetaphone.pyx
      Traceback (most recent call last):
        File "/usr/local/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
          main()
        File "/usr/local/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/usr/local/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 143, in get_requires_for_build_wheel
          return hook(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-ml8nh3dq/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 331, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-ml8nh3dq/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-ml8nh3dq/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 512, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/tmp/pip-build-env-ml8nh3dq/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 317, in run_setup
          exec(code, locals())
        File "<string>", line 12, in <module>
        File "/tmp/pip-build-env-ml8nh3dq/overlay/lib/python3.12/site-packages/Cython/Build/Dependencies.py", line 1145, in cythonize
          cythonize_one(*args)
        File "/tmp/pip-build-env-ml8nh3dq/overlay/lib/python3.12/site-packages/Cython/Build/Dependencies.py", line 1289, in cythonize_one
          raise CompileError(None, pyx_file)
      Cython.Compiler.Errors.CompileError: doublemetaphone/doublemetaphone.pyx
      [end of output]
```

Assuming it has to do with https://github.com/cython/cython/pull/6374
All tests pass after this change.
